### PR TITLE
会社の詳細情報からメールアドレスを抽出するRubyスクリプトをrake taskに移行した

### DIFF
--- a/app/models/company_2.rb
+++ b/app/models/company_2.rb
@@ -1,0 +1,2 @@
+class Company2 < ApplicationRecord
+end

--- a/db/migrate/20190114140300_create_company_2s.rb
+++ b/db/migrate/20190114140300_create_company_2s.rb
@@ -1,0 +1,9 @@
+class CreateCompany2s < ActiveRecord::Migration[5.2]
+  def change
+    create_table :company_2s do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/lib/tasks/company_2.rake
+++ b/lib/tasks/company_2.rake
@@ -1,0 +1,51 @@
+require 'open-uri'
+require 'nokogiri'
+require 'csv'
+require 'byebug'
+require 'kconv'
+
+namespace :company_2 do
+  def get_data(uri, data)
+    companies = data[0]
+    parameters = data[1]
+    html = open(uri).read
+    documents = Nokogiri::HTML(html.toutf8, nil, 'utf-8')
+    #byebug
+    companies << documents.xpath("//h1[@class='ts-h-company-mainTitle']").text
+    #byebug
+    parameters << documents.xpath("//div[@class='ts-h-company-sentence']")[1].text.strip.gsub(/(\r)/, " ")
+    return [companies, parameters]
+  end
+
+  def main()
+    uri = "https://job.rikunabi.com/2019/company/r294900083/"
+    puts "What is the maximum page? "
+    page = gets.to_i
+
+    companies = []
+    parameters = []
+    data = [companies, parameters]
+    data = get_data(uri,data)
+    (2..page).to_a.each do |idx|
+      uri = "https://job.rikunabi.com/2019/company/r294900083/"
+      data = get_data(uri,data)
+    end
+
+    len = [companies.size,parameters.size].min - 1
+
+    headers = ["会社名","Email"]
+    time = Time.new.strftime("%Y-%m-%d")
+    CSV.open("rikunabi_tokyo_2019-#{time}.csv", "a",headers: headers, write_headers: true) do |csv|
+      (0..len).to_a.each do |idx|
+        csv_column_values = [companies[idx], parameters[idx]]
+        csv << csv_column_values
+      end
+    end
+  end
+
+  if __FILE__ == $0
+    puts("Process Start")
+    main()
+    puts("Process Finished")
+  end
+end

--- a/test/fixtures/company_2s.yml
+++ b/test/fixtures/company_2s.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+
+two:
+  name: MyString

--- a/test/models/company_2_test.rb
+++ b/test/models/company_2_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class Company2Test < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# 概要

`list_rikunabi_2.rb` に実装していた会社の詳細情報ページからメールアドレスを抽出するためのスクリプトを`rake task`に移行した

# タスク

- [x] `rake task`の作成と`list_rikunabi_2.rb`の実装を移行した